### PR TITLE
fix bypass non escaped characters

### DIFF
--- a/sources/logger.c
+++ b/sources/logger.c
@@ -169,7 +169,7 @@ __attribute__((hot)) static inline int od_logger_escape(char *dest, int size,
 
 	while (msg_pos < msg_end) {
 		char escaped_char;
-		escaped_char = od_logger_escape_tab[(int)*msg_pos];
+		escaped_char = od_logger_escape_tab[(unsigned char)*msg_pos];
 		if (od_unlikely(escaped_char)) {
 			if (od_unlikely((dst_end - dst_pos) < 2)) {
 				break;


### PR DESCRIPTION
Problem
  in the od_logger_escape function at sources/logger.c:                                                                                             
                                                                                                                                                                                        
  escaped_char = od_logger_escape_tab[(int)*msg_pos];                                                                                                                                   
                                                                                                                                                                                        
  When *msg_pos contains a non-ASCII byte (value > 127), and char is signed (which is typical on Linux), casting to int sign-extends the value to a negative number. For example:       
  - UTF-8 byte 0xD0 (208) \u2192 becomes -48 as signed char \u2192 array index -48                                                                                                                
  - This causes undefined behavior - reading memory outside the array bounds  

Solution
  The fix is to cast to unsigned char instead of int

Result
  No more garbled output like \#020\xFB for Cyrillic text 
  